### PR TITLE
test: スクレイピングパーサの単体テストとCIを整備 (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ npm run build
 npm run preview
 ```
 
+テスト（`node --test`。スクレイピングパーサの単体テスト）:
+
+```sh
+npm test
+```
+
 ## デプロイ
 
 Cloudflare Workers にデプロイする。`wrangler login` 済みであること。

--- a/docs/agent-worklog.md
+++ b/docs/agent-worklog.md
@@ -1,5 +1,29 @@
 # Agent Worklog
 
+## 2026-06-08
+
+### Plan
+
+- 現状コードを評価し、レポートと Issue にまとめる。
+- 気になる点を Issue 化し（#32〜#36）、優先度順に潰す。
+- まず #32（テスト基盤）から着手する。
+
+### Work Log
+
+- コードレビュー結果を `docs/code-review-2026-06-08.md` に出力した。
+- 気になる点 5 件を Issue 化（#32 テスト / #33 worker分割 / #34 HTMLRewriter共通化 /
+  #35 チーム名マスタ統合 / #36 自前PNGの要否）。
+- #32 着手: `node --test` でスクレイピングパーサの単体テストを追加。
+  - `shared/hrParkFactor.js` の純粋関数 4 つ（チーム名正規化・球場名正規化・
+    試合詳細パース・本塁打中立換算）を対象にした。
+  - `parseNpbGameDetail` は npb.jp の実 HTML（2024/05/01 巨人対ヤクルト）を
+    `test/fixtures/` に固定し、HTML 構造変更を検知できるようにした。
+  - `package.json` に `test` スクリプト、`.github/workflows/ci.yml` に push/PR の CI を追加。
+
+### Verification
+
+- `npm test` で 7 テストすべて緑（pass 7 / fail 0）。
+
 ## 2026-06-07
 
 ### Plan

--- a/docs/code-review-2026-06-08.md
+++ b/docs/code-review-2026-06-08.md
@@ -1,0 +1,60 @@
+# コードレビュー 2026-06-08
+
+npbinfo の現状コードを評価したレポート。対象は `main` ブランチ（最新コミット `238e92f`）。
+
+## 全体像
+
+| コンポーネント | 役割 |
+| --- | --- |
+| `worker/index.js` | 本体 Worker。API + 静的配信。npb.jp を `HTMLRewriter` でスクレイプ、KV キャッシュ、年度別 TTL、暫定順位の自前再計算、OGP の SVG/PNG 生成 |
+| `stats-worker/index.js` | 本塁打パークファクターの差分バッチ。KV 経由で本体のキャッシュを無効化して連携 |
+| `og-worker/index.js` | Browser Rendering で日本語 OGP 画像を生成、署名比較で差分だけ更新 |
+| `shared/hrParkFactor.js` + `scripts/build-hr-park-factors.mjs` | 回帰補正つきパークファクターをオフライン算出 |
+| `src/` | React + Vite のフロント（順位表 / 選手成績 / 試合日程 / 球場情報） |
+
+KV をメッセージバス代わりにして 3 Worker を疎結合に繋ぐ構成。`og-worker` の signature 差分更新（`og-worker/index.js`）と `stats-worker` の cutoff 連携は実運用を意識した作り。
+
+## 良い点
+
+- **障害設計が堅実**。KV の get/put 失敗は `console.warn` で握って継続（`worker/index.js`）、上流が落ちたら 502 にして握りつぶさない。
+- **テーブル構造の世代差対応**。2024 以前 / 2026 以降の差を `isLegacy` で吸収（`worker/index.js` の `handleStats` ほか）。npb.jp の改定に実際に対応した跡。
+- **パークファクターが真面目**。中央値正規化 + ゲーム数による平均回帰（`scripts/build-hr-park-factors.mjs`）。サンプルの少ない球場を 1.000 に寄せる処理あり。
+- **依存ゼロの自前 PNG エンコーダ**。crc32/adler32/zlib store/ビットマップフォントを手書き（`worker/index.js`）。フォールバックとして機能。
+
+## 気になる点（対応 Issue）
+
+優先度順。1 件ずつ Issue として起票済み。
+
+| # | Issue | 内容 | 優先度 |
+| --- | --- | --- | --- |
+| 1 | [#32](https://github.com/kusanaginoturugi/npbinfo/issues/32) | スクレイピングパーサの単体テストと CI を整備する | 高 |
+| 2 | [#33](https://github.com/kusanaginoturugi/npbinfo/issues/33) | `worker/index.js`（2000 行超）を機能単位に分割する | 高 |
+| 3 | [#34](https://github.com/kusanaginoturugi/npbinfo/issues/34) | HTMLRewriter のテーブル走査ロジックを共通化する | 中 |
+| 4 | [#35](https://github.com/kusanaginoturugi/npbinfo/issues/35) | チーム名/色/コードのマスタを単一の真実源に統合する | 中 |
+| 5 | [#36](https://github.com/kusanaginoturugi/npbinfo/issues/36) | 自前 PNG エンコーダ(bitmap-fallback) の要否を判断する | 低 |
+
+### 1. テストがゼロ（#32）
+
+`git ls-files` に test ファイル無し、CI も無し。コアがスクレイピングのパーサ群（`mapCells` のインデックスマッピング、`parseNpbGameDetail` の正規表現、`applyFinishedGamesToStandings` の勝敗再計算）なのに、npb.jp が HTML を変えたら静かに壊れる。固定 HTML フィクスチャ → パーサ単体テストが最も投資対効果が高い。
+
+### 2. `worker/index.js` が一枚岩（#33）
+
+約 2011 行。標準/特別順位表・対戦表・選手成績・日程・天気・OGP(SVG+PNG) が全部同居。ルーターも素手の `if` パターンマッチが 10 連発。
+
+### 3. HTMLRewriter の状態機械がコピペ気味（#34）
+
+`inTable / tableDepth / targetTableDepth / cells / cellText` のテーブル走査が `buildStandingsRewriter` / `parseExtraStats` / `handleHeadToHead` でほぼ同型で 3〜4 回再発明されている。共通ヘルパーに寄せれば大幅削減できる。
+
+### 4. チーム名マスタの分散（#35）
+
+`TEAM_SHORT_NAMES` / `TEAM_COLORS`（worker と og-worker に別定義・色も微妙に不一致。ロッテが `#000000` vs `#111111`）/ `TEAM_ALIASES`（shared）/ `src/data/teams.js`。同じ 12 球団の別名・色・コードが 4 箇所にある。
+
+### 5. 自前 PNG エンコーダの立ち位置（#36）
+
+本番は `og-worker` の browser-run 優先で、worker 側のビットマップ PNG は `bitmap-fallback`。約 220 行をフォールバックのためだけに保守している。残すなら意図をコメントで明記、要らないなら削除も選択肢。
+
+## 総評
+
+最初の習作レベルから見ると、実運用を想定した分散構成・障害設計・データ更新パイプラインを自分で組めるところまで来ている。設計の方向は正しい。
+
+次の一歩は機能追加より **(1) パーサのテスト整備** と **(2) 一枚岩 Worker の分割・共通化**。ここを固めると npb.jp の仕様変更に強い土台になる。着手順は #32 → #33 → #34 → #35 → #36 を推奨（テストを先に入れてからリファクタするとリグレッションを検知できる）。

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "test": "node --test",
     "dev": "concurrently \"vite\" \"wrangler dev\"",
     "build": "vite build",
     "preview": "npm run build && wrangler dev",

--- a/test/fixtures/game-detail-2024-0501-g-s-05.html
+++ b/test/fixtures/game-detail-2024-0501-g-s-05.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+	<link rel="canonical" href="https://npb.jp/scores/2024/0501/g-s-05/">
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WS88V3F');</script>
+<!-- End Google Tag Manager -->
+
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="copyright" content="Nippon Professional Baseball Organization.">
+<meta name="author" content="一般社団法人日本野球機構">
+<meta name="keywords" content="野球,プロ野球,野球機構,日本野球機構,日本プロフェッショナル野球組織,ＮＰＢ,NPB,セ・リーグ,パ・リーグ,交流戦,日本シリーズ,オールスター">
+<meta name="description" content="日本野球機構（NPB）オフィシャルサイト。プロ野球12球団の試合日程・結果や予告先発、ドラフト会議をはじめ、事業・振興に関する情報を掲載。また、オールスター･ゲームや日本シリーズなど主催試合のチケット情報もご覧いただけます。">
+<meta name="viewport" content="width=1100">
+<meta name="format-detection" content="telephone=no">
+<link rel="apple-touch-icon" href="/img/webclip.png">
+<link rel="Shortcut Icon" href="/img/favicon.ico" type="image/x-icon">
+
+<!--[if lt IE 9]>
+<script src="/common/js/html5shiv.min.js"></script>
+<![endif]-->
+
+<script type="text/javascript" src="/common/js/jquery-1.11.3.min.js"></script>
+<script type="text/javascript" src="/common/js/jquery.easing.js"></script>
+<script type="text/javascript" src="/common/js/jquery.flicksimple.js"></script>
+<script type="text/javascript" src="/common/js/common.js"></script>
+<script type="text/javascript" src="/common/js/device.js?_2026052601"></script>
+<link rel="stylesheet" href="/common/css/format.css" />
+
+	<script type="text/javascript" src="/common/js/jquery.tablefix_1.0.1.js"></script>
+	<script>
+		ua.loadCSS([
+			"/common/css/layout.css",
+			"/common/css/common.css",
+			"/common/css/score_2018.css"
+		]);
+		$(function(){
+			if ( ua.isSP ) {
+				var w1 = $('#table_linescore').width();
+				$('#tablefix_ls').tablefix({width: w1});
+				}
+		});
+	</script>
+	<meta property="og:type" content="article">
+	<meta property="og:locale" content="ja_JP">
+	<meta property="og:url" content="https://npb.jp/scores/2024/0501/g-s-05/">
+	<meta property="og:site_name" content="NPB.jp 日本野球機構">
+	<meta property="og:title" content="試合速報">
+	<meta property="og:description" content="">
+	<meta property="og:image" content="https://p.npb.jp/img/ogp/default.jpg">
+	<meta property="fb:app_id" content="642572735845596">
+	<title>試合速報 | NPB.jp 日本野球機構</title>
+<script>
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	ga('create', 'UA-71379438-1', 'auto');
+	ga('send', 'pageview');
+
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XJYGG95SMT"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-XJYGG95SMT');
+</script>
+</head>
+<body>
+	<div id="layout">
+
+  <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WS88V3F"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<header>
+  <!-- 試合速報のインクルード取込 ここから -->
+  <div id="header_score">
+  <div class="score_wrap">
+    <div class="score_box date"><div>2026<br>6/8 Mon.</div></div>
+
+        <div class="score_box">
+      <a href="/scores/2026/0608/t-e-03/">
+      <div>
+        <img src="/img/common/logo/2026/logo_t_s.gif" alt="阪神タイガース" title="阪神タイガース" class="logo_left">
+        <img src="/img/common/logo/2026/logo_e_s.gif" alt="東北楽天ゴールデンイーグルス" title="東北楽天ゴールデンイーグルス" class="logo_right">
+        <div class="score">-</div>
+        <div class="state">（甲子園）<br class="hide_pc">18:00</div>
+      </div>
+      </a>
+    </div>
+    
+    <div class="score_box detail hide_sp"><a href="/scores/">&gt;&gt;</a></div>
+  </div>
+  <div class="score_box detail hide_pc"><a href="/scores/">&gt;&gt;</a></div>
+</div>
+<script>
+$(function($) {
+  $('#header_team').addClass("hide_pc");
+});
+</script>
+
+  <!-- 試合速報のインクルード取込 ここまで -->
+  
+  <div id="header_team" class="hide_sp">
+    <div class="team_list">
+      <ul class="league">
+        <li><a href="/cl/" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/flag_central_s.gif" width="59" height="38" alt="セントラル・リーグ" title="セントラル・リーグ"></a></li>
+        <li><a href="http://hanshintigers.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_t_m.gif" width="38" height="38" alt="阪神タイガース" title="阪神タイガース"></a></li>
+        <li><a href="http://www.baystars.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_db_m.gif" width="38" height="38" alt="横浜DeNAベイスターズ" title="横浜DeNAベイスターズ"></a></li>
+        <li><a href="http://www.giants.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_g_m.gif" width="38" height="38" alt="読売ジャイアンツ" title="読売ジャイアンツ"></a></li>
+        <li><a href="http://dragons.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_d_m.gif" width="38" height="38" alt="中日ドラゴンズ" title="中日ドラゴンズ"></a></li>        
+        <li><a href="http://www.carp.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_c_m.gif" width="38" height="38" alt="広島東洋カープ" title="広島東洋カープ"></a></li>
+        <li><a href="http://www.yakult-swallows.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_s_m.gif" width="38" height="38" alt="東京ヤクルトスワローズ" title="東京ヤクルトスワローズ"></a></li>
+      </ul>
+      <ul class="league">
+        <li><a href="/pl/" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/flag_pacific_s.gif" width="59" height="38" alt="パシフィック・リーグ" title="パシフィック・リーグ"></a></li>
+        <li><a href="http://www.softbankhawks.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_h_m.gif" width="38" height="38" alt="福岡ソフトバンクホークス" title="福岡ソフトバンクホークス"></a></li>
+        <li><a href="http://www.fighters.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_f_m.gif" width="38" height="38" alt="北海道日本ハムファイターズ" title="北海道日本ハムファイターズ"></a></li>
+        <li><a href="http://www.buffaloes.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_b_m.gif" width="38" height="38" alt="オリックス・バファローズ" title="オリックス・バファローズ"></a></li>
+        <li><a href="http://www.rakuteneagles.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_e_m.gif" width="38" height="38" alt="東北楽天ゴールデンイーグルス" title="東北楽天ゴールデンイーグルス"></a></li>
+        <li><a href="http://www.seibulions.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_l_m.gif" width="38" height="38" alt="埼玉西武ライオンズ" title="埼玉西武ライオンズ"></a></li>
+        <li><a href="http://www.marines.co.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_m_m.gif" width="38" height="38" alt="千葉ロッテマリーンズ" title="千葉ロッテマリーンズ"></a></li>
+      </ul>
+      <ul class="samurai">
+        <li><a href="http://www.japan-baseball.jp/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/logo_samurai_s.gif" width="49" height="49" alt="侍ジャパン" title="侍ジャパン"></a></li>
+      </ul>
+    </div>
+  </div>
+  
+  <div id="header_nav">
+    <div class="wrap">
+      <h1><a href="/">日本野球機構オフィシャルサイト</a></h1>
+      <nav>
+        <ul>
+          <li>
+            <a href="/games/" class="js-menuCategory close">試合</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/games/">セ・パ公式戦</a></li>
+                <li><a href="/announcement/">公示</a></li>
+                <li><a href="/interleague/">セ・パ交流戦</a></li>
+                <li><a href="/nippons/">日本シリーズ</a></li>
+                <li><a href="/allstar/">オールスター・ゲーム</a></li>
+                <li><a href="/preseason/">オープン戦</a></li>
+                <li><a href="/exhibition/">特別試合</a></li>
+              </ul>
+              <ul>
+                <li><a href="/farm/">ファーム公式戦</a></li>
+                <li><a href="/farmchamp/">ファーム日本選手権</a></li>
+                <li><a href="/freshas/">フレッシュオールスター・ゲーム</a></li>
+                <li><a href="/challenge/">イースタン・リーグ チャレンジ・マッチ</a></li>
+                <li><a href="/preseason_farm/">春季教育リーグ</a></li>
+                <li><a href="/phoenix/">秋季教育リーグ</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="/bis/" class="js-menuCategory close">成績・記録</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/bis/">シーズン成績</a></li>
+                <li><a href="/award/">表彰選手</a></li>
+                <li><a href="/history/">達成記録</a></li>
+                <li><a href="/bis/yearly/">年度別成績（1936-2025）</a></li>
+                <li><a href="/bis/history/">歴代最高記録（通算記録・シーズン記録）</a></li>
+                <li><a href="/stadium/">球場情報</a></li>
+                <li><a href="/statistics/">統計データ</a></li>
+              </ul>
+              <ul>
+                <li><a href="/scoring/">野球の記録について</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="/teams/" class="js-menuCategory close">球団・選手</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/teams/">球団別インデックス</a></li>
+                <li><a href="/bis/teams/">選手一覧</a></li>
+                <li><a href="/bis/players/">個人年度別成績</a></li>
+                <li><a href="/history/register/">プロ野球在籍者名簿</a></li>
+                <li><a href="/announcement/">公示</a></li>
+                <li><a href="/draft/">ドラフト会議</a></li>
+                <li><a href="/camp/">キャンプガイド</a></li>
+              </ul>
+              <ul>
+                <li><a href="/cl/">セントラル・リーグ</a></li>
+                <li><a href="/pl/">パシフィック・リーグ</a></li>
+                <li><a href="/umpires/">審判員・記録員</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="/japan/" class="js-menuCategory close">日本代表</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/wbc/">ワールド・ベースボール・クラシック</a></li>
+                <li><a href="/premier/">WBSC プレミア12</a></li>
+                <li><a href="/olympic/">オリンピック競技大会</a></li>
+                <li><a href="/apbc/">アジア プロ野球チャンピオンシップ</a></li>
+                <li><a href="/japan/">侍ジャパン強化試合</a></li>
+                <li><a href="/japanus/">日米野球</a></li>
+                <li><a href="/alljapan/">野球日本代表（その他）</a></li>
+              </ul>
+              <ul>
+                <li><a href="/asia/">アジアシリーズ／日韓クラブCS</a></li>
+                <li><a href="/winterleague/">ウインター・リーグ</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="/news/npb_all.html" class="js-menuCategory close">ニュース</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/news/npb_all.html">NPBニュース</a></li>
+                <li><a href="/news/teamnews_all.html">12球団ニュース</a></li>
+                <li><a href="/npb/#ctg56">新型コロナウイルス感染症対策</a></li>
+                <li><a href="/npb/">NPBからのお知らせ</a></li>
+                <li><a href="/event/">プロ野球年間行事日程</a></li>
+                <!-- <li><a href="/event/nenkan/">スケジュールカレンダー</a></li> -->
+                <li><a href="/video/">NPBムービー</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="/promotion/" class="js-menuCategory close">事業・振興</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/slogan/">NPBスローガン</a></li>
+                <li><a href="/npb/#ctg01">約款・規定</a></li>
+                <li><a href="/npb/#ctg02">暴力団等排除活動</a></li>
+                <li><a href="/npb/batmakers.html">NPB公認バットメーカー一覧</a></li>
+                <li><a href="/anti-doping/">アンチ・ドーピング</a></li>
+                <li><a href="/rookie/">新人選手研修会</a></li>
+                <li><a href="/secondcareer/">セカンドキャリア</a></li>
+              </ul>
+              <ul>
+                <li><a href="/npb/kaifuku.html">学生野球資格回復制度</a></li>
+                <li><a href="/umpireschool/">NPBアンパイア・スクール</a></li>
+                <li><a href="/promotion/">野球振興</a></li>
+                <li><a href="/junior/">NPBジュニアトーナメント</a></li>
+                <li><a href="/girls/">NPBガールズトーナメント</a></li>
+                <li><a href="/npb/#ctg21">東日本大震災復興支援</a></li>
+                <li><a href="/bbfesta/">ベースボールフェスタ</a></li>
+              </ul>
+              <ul>
+                <li><a href="/auction/">チャリティーオークション</a></li>
+                <li><a href="/gbp/">NPB Green Baseball Project</a></li>
+                <li><a href="/cool/">環境貢献活動</a></li>
+                <li><a href="/esports/">eスポーツ</a></li>
+                <li><a href="/kyogikai/">日本野球協議会</a></li>
+                <li><a href="/archives/">アーカイブ</a></li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <a href="http://shop.npb.or.jp/npbshop/ad.html?ccd=t10092408" class="js-menuCategory close" target="_blank" onclick="ga('send', 'event', 'menu', 'click', this.href);">グッズ</a>
+            <div class="menu unit">
+              <ul>
+                <li><a href="/books/">グッズ・書籍のご案内</a></li>
+                <li><a href="/game/">承認ゲームメーカー</a></li>
+                <li><a href="http://shop.npb.or.jp/npbshop/ad.html?ccd=t10092408" target="_blank" onclick="ga('send', 'event', 'gd_menu', 'click', this.href);">NPBオフィシャルオンラインショップ</a></li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </nav>
+      <div class="social">
+        <ul>
+          <li><a href="/eng/">English</a></li>
+          <li class="tw"><a href="https://twitter.com/npb" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"></a></li>
+          <li class="fb"><a href="https://www.facebook.com/npb.official/" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"></a></li>
+          <li class="yt"><a href="https://www.youtube.com/@NPB.official" target="_blank" onclick="ga('send', 'event', 'header', 'click', this.href);"></a></li>
+          <li class="sp_menu hide_pc" id="sp_menu"><a href="#"></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+
+<script>
+  if ( Math.random() > 0.5 ) {
+    $("h1").addClass("sh");
+  }
+  else {
+    $("h1").addClass("kd");
+  }
+  
+  if ( ua.isSP ) {
+    $(".js-menuCategory").on("click", function(){
+      if ( $(this).hasClass("open") ) {
+        $(this).removeClass("open");
+        $(this).next().stop().slideUp(400);
+      }
+      else {
+        $(this).addClass("open");
+        $(this).next().stop().slideDown(400);
+      }
+      
+      return false;
+    });
+  }
+</script>
+
+
+      <h2 class="cate_score">
+      <div>
+        <span id="h2_text"><a href="/scores/">試合速報</a></span>
+        <span id="h2_score_vs">
+          <table>
+            <tr>
+              <th><img src="/img/common/logo/2024/logo_g_m_t.png" width="76" height="76" alt="読売ジャイアンツ"></th>
+              <td>VS</td>
+              <th><img src="/img/common/logo/2024/logo_s_m_t.png" width="76" height="76" alt="東京ヤクルトスワローズ"></th>
+            </tr>
+          </table>
+        </span>
+      </div>
+    </h2>
+  <div class="contents">
+    <div class="score_nav">
+      <ul>
+        <li class="current">試合TOP</li>
+        <li><a href="./playbyplay.html">試合経過</a></li>
+        <li><a href="./box.html">投打成績</a></li>
+                <li><a href="./roster.html">ベンチ入り選手</a></li>
+              </ul>
+    </div>
+
+    <div class="wrap" id="game_stats">
+  <div class="game_tit">
+    <time>2024年5月1日（水）</time>
+    <span class="place">東京ドーム</span>
+    <h3>【JERA セ・リーグ公式戦】 読売ジャイアンツ vs 東京ヤクルトスワローズ 
+    5回戦    </h3>
+  </div>
+  <div class="line-score">
+    <p class="game_info">
+            【試合終了】
+            ◇開始 18:00        ◇終了 20:38            ◇試合時間 2時間38分      ◇入場者 41,260人
+          </p>
+    <div id="table_linescore">
+      <table id="tablefix_ls">
+  <thead>
+    <tr>
+      <th>&nbsp;</th>
+              <th>1</th>
+              <th>2</th>
+              <th>3</th>
+              <th>4</th>
+              <th>5</th>
+              <th>6</th>
+              <th>7</th>
+              <th>8</th>
+              <th>9</th>
+                                                                                                                                                                                                                                                                                                                  <td class="total-1">計</td>
+      <td class="total-2">H</td>
+      <td class="total-2">E</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="top">
+      <th>
+        <span class="flag_s_2024"><span class="hide_sp">東京ヤクルトスワローズ</span><span class="hide_pc">ヤクルト</span></span>
+      </th>
+              <td>3</td>
+              <td>0</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+                                                                                                                                                                                                                                                                                                                  <td class="total-1">4</td>
+      <td class="total-2">8</td>
+      <td class="total-2">0</td>
+    </tr>
+    <tr class="bottom">
+      <th>
+        <span class="flag_g_2024"><span class="hide_sp">読売ジャイアンツ</span><span class="hide_pc">巨人</span></span>
+      </th>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+                                                                                                                                                                                                                                                                                                                  <td class="total-1">0</td>
+      <td class="total-2">7</td>
+      <td class="total-2">0</td>
+    </tr>
+  </tbody>
+</table>
+    </div>
+  </div>
+      <p class="referee_info">
+    球審：嶋田    、塁審(一)：山本貴    、塁審(二)：山路    、塁審(三)：市川          </p>
+    </div>
+
+      <div class="wrap">
+      <section class="game_result_info">
+              <table>
+            <tbody>
+                            <tr>
+                <th>【勝投手】</th>
+                                <td><a href="/bis/players/53555157.html">吉村</a>（2勝2敗）</td>
+              </tr>
+                                          <tr>
+                <th>【敗投手】</th>
+                                <td><a href="/bis/players/51155155.html">赤星</a>（0勝3敗）</td>
+              </tr>
+                                        </tbody>
+          </table>
+    
+          <h4>バッテリー</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>【ヤクルト】</th>
+                            <td><a href="/bis/players/53555157.html">吉村</a>、<a href="/bis/players/93195136.html">山本</a>、<a href="/bis/players/41545151.html">大西</a>　‐　<a href="/bis/players/51255118.html">中村</a></td>
+            </tr>
+            <tr>
+              <th>【巨人】</th>
+                            <td><a href="/bis/players/51155155.html">赤星</a>、<a href="/bis/players/91795155.html">京本</a>、<a href="/bis/players/31335135.html">今村</a>、<a href="/bis/players/01105138.html">泉</a>、<a href="/bis/players/21625151.html">堀田</a>　‐　<a href="/bis/players/91595136.html">岸田</a>、<a href="/bis/players/21325136.html">大城卓</a></td>
+            </tr>
+          </tbody>
+        </table>
+      <h4>本塁打</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>【ヤクルト】</th>
+                            <td><a href="/bis/players/23525153.html">オスナ</a> 6号（1回3ラン <a href="/bis/players/51155155.html">赤星</a>）、<a href="/bis/players/41845136.html">村上</a> 6号（3回ソロ <a href="/bis/players/51155155.html">赤星</a>）</td>
+            </tr>
+            <tr>
+              <th>【巨人】</th>
+                            <td></td>
+            </tr>
+          </tbody>
+        </table>
+          </section>
+    </div>
+
+    
+        <div class="wrap" id="player-order">
+      <h4>最新のオーダー</h4>
+      <div class="half_left">
+        <h5>東京ヤクルトスワローズ</h5>
+<table>
+  <tbody>
+    <tr>
+      <th>1</th>
+      <th>中</th>
+            <td><a href="/bis/players/21225133.html">西川</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <th>右</th>
+            <td><a href="/bis/players/93195155.html">丸山和</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <th>一</th>
+            <td><a href="/bis/players/23525153.html">オスナ</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <th>三</th>
+            <td><a href="/bis/players/21525136.html">北村拓</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>5</th>
+      <th>左</th>
+            <td><a href="/bis/players/51355155.html">岩田</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>6</th>
+      <th>二</th>
+            <td><a href="/bis/players/71275151.html">武岡</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>7</th>
+      <th>遊</th>
+            <td><a href="/bis/players/51455151.html">長岡</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>8</th>
+      <th>捕</th>
+            <td><a href="/bis/players/51255118.html">中村</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>9</th>
+      <th>投</th>
+            <td><a href="/bis/players/41545151.html">大西</a></td>
+      <td>&nbsp;</td>
+    </tr>
+  </tbody>
+</table>
+      </div>
+      <div class="half_right">
+        <h5>読売ジャイアンツ</h5>
+<table>
+  <tbody>
+    <tr>
+      <th>1</th>
+      <th>左</th>
+            <td><a href="/bis/players/21425116.html">丸</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <th>右</th>
+            <td><a href="/bis/players/51955159.html">佐々木</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <th>二</th>
+            <td><a href="/bis/players/73375134.html">吉川</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <th>一</th>
+            <td><a href="/bis/players/11515130.html">岡本和</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>5</th>
+      <th>三</th>
+            <td><a href="/bis/players/51955114.html">坂本</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>6</th>
+      <th>中</th>
+            <td><a href="/bis/players/81485157.html">萩尾</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>7</th>
+      <th>投</th>
+            <td><a href="/bis/players/21625151.html">堀田</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>8</th>
+      <th>遊</th>
+            <td><a href="/bis/players/11515157.html">門脇</a></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th>9</th>
+      <th>捕</th>
+            <td><a href="/bis/players/21325136.html">大城卓</a></td>
+      <td>&nbsp;</td>
+    </tr>
+  </tbody>
+</table>
+      </div>
+    </div>
+    
+    </div>
+  <!-- 250904 ボタン追加 -->
+<button id="js-pagetop" class="btn-pagetop"><span class="btn-pagetop__arrow"></span></button>
+<!-- /250904 ボタン追加 -->
+
+<footer>
+<div id="footer_team">
+    <div class="team_list">
+        <ul class="league">
+            <li><a href="/cl/" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/flag_central_s.gif" width="59" height="38" alt="セントラル・リーグ" title="セントラル・リーグ"></a></li>
+            <li><a href="http://hanshintigers.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_t_m.gif" width="38" height="38" alt="阪神タイガース" title="阪神タイガース"></a></li>
+            <li><a href="http://www.baystars.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_db_m.gif" width="38" height="38" alt="横浜DeNAベイスターズ" title="横浜DeNAベイスターズ"></a></li>
+            <li><a href="http://www.giants.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_g_m.gif" width="38" height="38" alt="読売ジャイアンツ" title="読売ジャイアンツ"></a></li>
+            <li><a href="http://dragons.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_d_m.gif" width="38" height="38" alt="中日ドラゴンズ" title="中日ドラゴンズ"></a></li>
+            <li><a href="http://www.carp.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_c_m.gif" width="38" height="38" alt="広島東洋カープ" title="広島東洋カープ"></a></li>
+            <li><a href="http://www.yakult-swallows.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_s_m.gif" width="38" height="38" alt="東京ヤクルトスワローズ" title="東京ヤクルトスワローズ"></a></li>   
+        </ul>
+        <ul class="league">
+            <li><a href="/pl/" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/flag_pacific_s.gif" width="59" height="38" alt="パシフィック・リーグ" title="パシフィック・リーグ"></a></li>
+            <li><a href="http://www.softbankhawks.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_h_m.gif" width="38" height="38" alt="福岡ソフトバンクホークス" title="福岡ソフトバンクホークス"></a></li>
+            <li><a href="http://www.fighters.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_f_m.gif" width="38" height="38" alt="北海道日本ハムファイターズ" title="北海道日本ハムファイターズ"></a></li>
+            <li><a href="http://www.buffaloes.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_b_m.gif" width="38" height="38" alt="オリックス・バファローズ" title="オリックス・バファローズ"></a></li>
+            <li><a href="http://www.rakuteneagles.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_e_m.gif" width="38" height="38" alt="東北楽天ゴールデンイーグルス" title="東北楽天ゴールデンイーグルス"></a></li>
+            <li><a href="http://www.seibulions.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_l_m.gif" width="38" height="38" alt="埼玉西武ライオンズ" title="埼玉西武ライオンズ"></a></li>
+            <li><a href="http://www.marines.co.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/2026/logo_m_m.gif" width="38" height="38" alt="千葉ロッテマリーンズ" title="千葉ロッテマリーンズ"></a></li>
+        </ul>
+        <ul class="samurai">
+            <li><a href="http://www.japan-baseball.jp/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', this.href);"><img src="//p.npb.jp/img/common/logo/logo_samurai_s.gif" width="49" height="49" alt="侍ジャパン" title="侍ジャパン"></a></li>
+        </ul>
+    </div>
+</div>
+  
+<div class="footer_box">
+    <div class="wrap" id="footer_npb">
+        <div class="footer_inner_1">
+            <div class="footer_logo"><img src="//p.npb.jp/img/footer/logo_npb_footer.gif" width="377" height="37" alt="日本野球機構" title="日本野球機構"></div>
+        </div>
+        <!-- <hr class="hide_sp"> -->
+        <div class="footer_inner_2">
+            <ul class="footer_link">
+                <li><a href="/organization/">一般社団法人日本野球機構について</a></li>
+                <li><a href="/recruit/">採用情報</a></li>
+                <li><a href="/policy/">プライバシーポリシー</a></li>
+                <li><a href="/form/inquiry/">お問い合わせ</a></li>
+                <li><a href="/form/opinionbox/">ご意見箱</a></li>
+                <li><a href="/mailmaga/">メールマガジン</a></li>
+                <li><a href="/social/">ソーシャルメディア</a></li>
+                <li><a href="/sitemap/">サイトマップ</a></li>
+            </ul>
+        </div>
+        <div class="footer_inner_3">
+            <div class="copyright">Copyright (C) 1996-2026 Nippon Professional Baseball Organization. All Rights Reserved.<br>掲載の情報、画像、映像等の二次利用および無断転載を固く禁じます。</div>
+        </div>
+    </div>
+</div>
+
+</footer>
+
+</div>
+</body>
+</html>

--- a/test/hrParkFactor.test.js
+++ b/test/hrParkFactor.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  normalizeParkFactorTeam,
+  normalizeParkFactorVenue,
+  parseNpbGameDetail,
+  calculateAdjustedHomeRuns,
+} from '../shared/hrParkFactor.js';
+
+function fixture(name) {
+  return readFileSync(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url)), 'utf8');
+}
+
+test('normalizeParkFactorTeam: 正式名・短縮名・HTML混じりを短縮名へ寄せる', () => {
+  assert.equal(normalizeParkFactorTeam('読売ジャイアンツ'), '巨人');
+  assert.equal(normalizeParkFactorTeam('巨人'), '巨人');
+  assert.equal(normalizeParkFactorTeam('【東京ヤクルトスワローズ】'), 'ヤクルト');
+  assert.equal(normalizeParkFactorTeam('横浜DeNAベイスターズ'), 'DeNA');
+  // 未知の値はそのまま返す
+  assert.equal(normalizeParkFactorTeam('未知の球団'), '未知の球団');
+});
+
+test('normalizeParkFactorVenue: 球場の表記揺れを正規名へ寄せる', () => {
+  assert.equal(normalizeParkFactorVenue('ナゴヤドーム'), 'バンテリンドーム ナゴヤ');
+  assert.equal(normalizeParkFactorVenue('西武ドーム'), 'ベルーナドーム');
+  assert.equal(normalizeParkFactorVenue('千葉マリンスタジアム'), 'ZOZOマリンスタジアム');
+  assert.equal(normalizeParkFactorVenue('神宮'), '明治神宮野球場');
+  // 未知の球場はそのまま返す
+  assert.equal(normalizeParkFactorVenue('どこかの球場'), 'どこかの球場');
+});
+
+test('parseNpbGameDetail: 終了済み公式戦の実HTMLから試合詳細を抽出する', () => {
+  const html = fixture('game-detail-2024-0501-g-s-05.html');
+  const detail = parseNpbGameDetail(html, '/scores/2024/0501/g-s-05/');
+  assert.deepEqual(detail, {
+    path: '/scores/2024/0501/g-s-05/',
+    date: '2024-05-01',
+    venue: '東京ドーム',
+    homeTeam: '巨人',
+    awayTeam: 'ヤクルト',
+    homeHr: 0,
+    awayHr: 2,
+  });
+});
+
+test('parseNpbGameDetail: 試合終了マーカーが無ければ null', () => {
+  assert.equal(parseNpbGameDetail('<html><body>試合前</body></html>'), null);
+});
+
+test('parseNpbGameDetail: ファーム戦は対象外で null', () => {
+  const html = `
+    <div class="game_tit"><h3>【試合終了】イースタン・リーグ 巨人 vs ヤクルト 1回戦</h3></div>
+    <span class="place">東京ドーム</span>
+    <time>2024年5月1日</time>
+    <h4>本塁打</h4><table><tbody></tbody></table>`;
+  assert.equal(parseNpbGameDetail(html), null);
+});
+
+test('calculateAdjustedHomeRuns: 球場係数で本塁打を中立換算する', () => {
+  const games = [
+    { venue: 'A球場', homeTeam: '巨人', awayTeam: 'ヤクルト', homeHr: 2, awayHr: 0 },
+    { venue: 'B球場', homeTeam: 'ヤクルト', awayTeam: '巨人', homeHr: 1, awayHr: 3 },
+  ];
+  const factors = {
+    'A球場': { factor: 2 },   // 打者有利 → 割り引く
+    'B球場': { factor: 0.5 }, // 投手有利 → 割り増す
+  };
+  const result = calculateAdjustedHomeRuns(games, factors);
+  // 巨人: A球場 2本/2 + B球場 3本/0.5 = 1 + 6 = 7.0
+  assert.equal(result['巨人'].raw, 5);
+  assert.equal(result['巨人'].adjusted, 7);
+  // ヤクルト: A球場 0本/2 + B球場 1本/0.5 = 0 + 2 = 2.0
+  assert.equal(result['ヤクルト'].raw, 1);
+  assert.equal(result['ヤクルト'].adjusted, 2);
+});
+
+test('calculateAdjustedHomeRuns: 未知の球場は係数1として扱う', () => {
+  const games = [{ venue: '無名球場', homeTeam: '巨人', awayTeam: 'ヤクルト', homeHr: 4, awayHr: 0 }];
+  const result = calculateAdjustedHomeRuns(games, {});
+  assert.equal(result['巨人'].raw, 4);
+  assert.equal(result['巨人'].adjusted, 4);
+});


### PR DESCRIPTION
## 概要

Issue #32 の対応。コアであるスクレイピングパーサにテストが 1 本も無かったため、`node --test`（依存ゼロ）で単体テスト基盤を整備した。あわせて 2026-06-08 のコードレビューレポートを追加。

## 変更点

- `test/hrParkFactor.test.js`: `shared/hrParkFactor.js` の純粋関数 4 つをカバー
  - `normalizeParkFactorTeam` / `normalizeParkFactorVenue`（表記揺れの正規化）
  - `parseNpbGameDetail`（試合詳細パース。終了マーカー無し・ファーム戦の null も検証）
  - `calculateAdjustedHomeRuns`（本塁打の中立球場換算）
- `test/fixtures/game-detail-2024-0501-g-s-05.html`: npb.jp の実 HTML を固定。HTML 構造変更を検知できる
- `package.json`: `npm test` を追加
- `.github/workflows/ci.yml`: push(main) / PR で `npm ci && npm test`
- `docs/code-review-2026-06-08.md`: コードレビューレポート

## 確認

- `npm test` で 7 テストすべて緑（pass 7 / fail 0）

## 次の一歩

レポートで挙げた残り Issue を順に潰す: #33 → #34 → #35 → #36

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)